### PR TITLE
Reenable Hackage-friendly settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
 packages:
   - '.'
+pvp-bounds: both
 extra-deps:
   - data-has-0.2.1.0
   - wai-cli-0.1.1
   - refined-0.1.2.1
 resolver: lts-8.6
-pvp-bounds: none


### PR DESCRIPTION
It appears the setting from  #1 went missing while updating the resolver.