### PR TITLE
Updated for LTS 14.1.

### DIFF
--- a/library/Magicbane.hs
+++ b/library/Magicbane.hs
@@ -29,7 +29,7 @@ import           Network.URI as X
 import           Network.HTTP.Link as X hiding (Link)
 import           Network.HTTP.Types as X hiding (Header)
 import           Network.Wai as X (Application, Middleware)
-import           Network.Wai.Cli as X hiding (port)
+import           Network.Wai.Cli as X
 import           Magicbane.App as X hiding (Or)
 import           Magicbane.Config as X
 import           Magicbane.Has as X

--- a/library/Magicbane/Util.hs
+++ b/library/Magicbane/Util.hs
@@ -94,11 +94,11 @@ slugify = T.filter (not . isSpace) . T.intercalate "-" . T.words .
           T.filter (`onotElem` ("!^*?()[]{}`./\\'\"~|"::String)) .
           T.toLower . T.strip
 
--- | Creates a simple text/plain ServantErr.
-errText ∷ ServantErr → L.ByteString → ServantErr
+-- | Creates a simple text/plain ServerError
+errText ∷ ServerError → L.ByteString → ServerError
 errText e t = e { errHeaders = [ (hContentType, "text/plain; charset=utf-8") ]
                 , errBody    = t }
 
--- | Creates and throws a simple text/plain ServantErr.
-throwErrText ∷ MonadThrow μ ⇒ ServantErr → L.ByteString → μ α
+-- | Creates and throws a simple text/plain ServerError.
+throwErrText ∷ MonadThrow μ ⇒ ServerError → L.ByteString → μ α
 throwErrText e t = throwM $ errText e t

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: magicbane
-version: '0.4.0'
+version: '0.4.1'
 synopsis: >
   A web framework that integrates Servant, RIO, EKG, fast-logger, wai-cli…
 description: >
@@ -12,7 +12,7 @@ maintainer: greg@unrelenting.technology
 copyright: 2017-2018 Greg V <greg@unrelenting.technology>
 license: PublicDomain
 github: myfreeweb/magicbane
-tested-with: GHC==8.4.2
+tested-with: GHC==8.6.5
 dependencies:
   - base >=4.8.0.0 && <5
   - rio

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,13 @@
 packages:
   - '.'
-resolver: lts-13.6
+resolver: lts-14.1
 extra-deps:
-  - monad-metrics-0.2.1.2
+  - monad-metrics-0.2.1.4
   - wai-middleware-metrics-0.2.4
   - ekg-wai-0.1.0.3
   - ekg-json-0.1.0.6
   - wai-cli-0.2.0
+  - refined-0.4.2.2
+  - QuickCheck-2.12.6.1
+
 pvp-bounds: none


### PR DESCRIPTION
`ServantErr` got renamed to `ServerError`, causing a build failure.  There's one warning cleanup (w.r.t. `hiding (port)`) and some package updates to make stack happy.