### PR TITLE
Upgrade refined library version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In particular, Magicbane combines the following libraries:
 - [envy](https://www.stackage.org/package/envy) for configuration. [Store config in environment variables](https://12factor.net/config)!
 - [fast-logger](https://www.stackage.org/package/fast-logger) for logging. Integrated into RIO's logging API, and `monad-logger` as well for libraries that use it.
 - [EKG](https://www.stackage.org/package/ekg)+[monad-metrics](https://www.stackage.org/package/monad-metrics) for metrics. `monad-metrics` lets you easily measure things in your application: just use `label`/`counter`/`distribution`/`gauge`/`timed` in your handlers. The EKG ecosystem has backends for [InfluxDB](https://www.stackage.org/package/ekg-influxdb), [Carbon (Graphite)](https://www.stackage.org/package/ekg-carbon), [statsd](https://www.stackage.org/package/ekg-statsd), [Prometheus](https://www.stackage.org/package/ekg-prometheus-adapter) and others… And a simple local [web server](https://www.stackage.org/package/ekg-wai) for development.
-- [refined](https://nikita-volkov.github.io/refined/) for validation. Why use functions for input validation when you can use types? Magicbane integrates `refined` with Aeson, so you can write things like `count ∷ Refined Positive Int` in your data type definitions and inputs that don't satisfy the constraints will be rejected when input is processed.
+- [refined](https://nikita-volkov.github.io/refined/) for validation. Why use functions for input validation when you can use types?
 - [http-client](https://www.stackage.org/package/http-client)([-tls](https://www.stackage.org/package/http-client-tls)) for, well, making HTTP requests. Most high level HTTP client libraries are built on top of that. Magicbane provides a small composable interface based on [http-conduit](https://www.stackage.org/package/http-conduit), which lets you e.g. stream the response body directly into [an HTML parser](https://www.stackage.org/package/html-conduit).
 - [http-link-header](https://www.stackage.org/package/http-link-header) for the [HTTP `Link` header](https://tools.ietf.org/html/rfc5988#section-5), unsurprisingly.
 - [unliftio](https://www.stackage.org/package/unliftio) for uhhh [unlifting](https://github.com/fpco/unliftio/tree/master/unliftio#readme).
@@ -36,6 +36,8 @@ Not part of Magicbane, but recommended:
 - [pcre-heavy](https://www.stackage.org/package/pcre-heavy) for regular expressions.
 
 Magicbane was extracted from [Sweetroll](https://github.com/myfreeweb/sweetroll).
+
+
 
 ## Usage
 
@@ -112,6 +114,10 @@ Now we have metrics and logging instead of HTTP client and logging!
 `timed` is used here to measure how long it takes to say hello.
 
 See the `examples` directory for more examples.
+
+## A note regarding the `refined` library
+
+The `refined` library provides a way of working with  Refinement Types, so you can write things like `count ∷ Refined Positive Int` to give you a compile-time guarantee that count is a Positive Integer. Magicbane originally extended the `refined` library by intergating with Aeson, for validating JSON at type boundaries e.g. to refine/sanitise an unrefined external input to its refined internal type. This Aeson integration is now provided natively by the `refined` library, so now we just re-export `refined` here, for convenience.
 
 ## Development
 

--- a/library/Magicbane/Validation.hs
+++ b/library/Magicbane/Validation.hs
@@ -1,20 +1,10 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE OverloadedStrings, UnicodeSyntax #-}
 
--- | Integrates the refinement types from the refined library with aeson.
+-- | This module used to integrate the refinement types from the Refined library with aeson.
+-- | This integration is now included in Refined library (as of 0.4), but we keep the re-export for convenience.
 module Magicbane.Validation (
   module Refined
 ) where
 
 import           Refined
-import           Data.Aeson
-
-instance ToJSON α ⇒ ToJSON (Refined ρ α) where
-  toJSON = toJSON . unrefine
-
-instance (FromJSON α, Predicate ρ α) ⇒ FromJSON (Refined ρ α) where
-  parseJSON x = do
-    res ← parseJSON x
-    case refine res of
-      Right v → return v
-      Left e → fail $ show e

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: magicbane
-version: '0.5.0'
+version: '0.5.1'
 synopsis: >
   A web framework that integrates Servant, RIO, EKG, fast-logger, wai-cli…
 description: >

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,9 +7,9 @@ extra-deps:
   - ekg-wai-0.1.0.3
   - ekg-json-0.1.0.6
   - wai-cli-0.2.0
-  - refined-0.4.2.2
-  - QuickCheck-2.12.6.1
+  - refined-0.6.1
   - servant-server-0.18
   - servant-0.18
+  - these-skinny-0.7.4
 
 pvp-bounds: none

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -40,19 +40,12 @@ packages:
   original:
     hackage: wai-cli-0.2.0
 - completed:
-    hackage: refined-0.4.2.2@sha256:52adff15a70ed485a126b6fcf0e23a0f8ce1c949a4983af49ccb14a1d51c4fe1,2219
+    hackage: refined-0.6.1@sha256:d5d713f0a2ad79d1c049d2d132fd8c2078b883b5ea3db876087eaec102843e57,2748
     pantry-tree:
-      size: 674
-      sha256: 2036b61facdd97bca08b5865d129497d86767e0792f7ab4908b4672d27b92456
+      size: 562
+      sha256: 3b530f23657d5c8425b9512593417b2c65085719afa30e0d9d2bd72d4e4f7bd5
   original:
-    hackage: refined-0.4.2.2
-- completed:
-    hackage: QuickCheck-2.12.6.1@sha256:ce974f511174fbc3102bccb13d6d45781d327194f0311790b9f8db6a7cb1bab3,6336
-    pantry-tree:
-      size: 2046
-      sha256: 1b9bf780a91762f07a63698d656234de0b68f5c8de760cc90153c01888730eb5
-  original:
-    hackage: QuickCheck-2.12.6.1
+    hackage: refined-0.6.1
 - completed:
     hackage: servant-server-0.18@sha256:ec7f361bc9848968b1fff8091fa2213b721d3f47549421945c6a7ca1702e22e6,5424
     pantry-tree:
@@ -67,6 +60,13 @@ packages:
       sha256: 701b6443e486601dd127b92a28ca052278dea8dc528f013781c1304826e117d8
   original:
     hackage: servant-0.18
+- completed:
+    hackage: these-skinny-0.7.4@sha256:e29336a1a70a497e09d8266f8438efb30a807bafaa6b00f5a136f7493efb3160,1239
+    pantry-tree:
+      size: 262
+      sha256: 77f01554e40d8e910d00f95c35dde86df4f691e2955d9afdc16508114c4d1af2
+  original:
+    hackage: these-skinny-0.7.4
 snapshots:
 - completed:
     size: 523448


### PR DESCRIPTION
This pull request upgrades the `refined` library version to 0.6.1. 

This has a couple of benefits:

1. Removes tight restrictions on QuickCheck versions, resulting from the old version of `refined`
2. Allows removal of the ToJSON and FromJSON instances in the Validation module

The removal of the `ToJSON` and `FromJSON` for refinement types in the Validation module was actually necessary because they have now been implemented natively in the `refined` library. We still re-export the refined module so that backwards compatibility is maintained.

Please tag with 0.5.1 following this pull request, if accepted.